### PR TITLE
Fixed link to repository

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,10 @@
   "version": "1.0.9",
   "description": "Plugin to support node-config usage within webpack",
   "main": "node-config-plugin.js",
-  "repository": "git@github.com:icarus-sullivan/node-config-webpack.git",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/icarus-sullivan/node-config-webpack.git"
+  },
   "author": "Chris Sullivan <chrissullivan.dev@gmail.com>",
   "files": [
     "./node-config-plugin.js"


### PR DESCRIPTION
Currently... https://www.npmjs.com/package/node-config-webpack
does not link to the code or issue list for this package.